### PR TITLE
Integrate Milton link processor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,15 @@ repositories {
     jcenter()
 }
 
+val ktor_version = "1.3.2"
+
 dependencies {
     implementation(kotlin("stdlib"))
 
     implementation("com.discord4j:discord4j-core:3.0.13")
+    implementation("io.ktor:ktor-client-okhttp:$ktor_version")
+    implementation("io.ktor:ktor-client-gson:$ktor_version")
+    implementation("io.ktor:ktor-client-json:$ktor_version")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")

--- a/coffeebot
+++ b/coffeebot
@@ -1,3 +1,3 @@
 # /bin/bash
-./gradlew --build-cache installDist
+./gradlew --build-cache installDist &&
 ./build/install/coffeebot/bin/coffeebot $@

--- a/src/main/kotlin/coffeebot/commands/Commands.kt
+++ b/src/main/kotlin/coffeebot/commands/Commands.kt
@@ -1,24 +1,9 @@
 package coffeebot.commands
 
+import coffeebot.message.Passive
 import coffeebot.message.Valid
 
-interface CommandHandler {
-    fun handle(valid: Valid, backfill: Boolean)
-
-    companion object {
-        fun fromHandle(handle: (Valid) -> Unit) = object : CommandHandler {
-            override fun handle(valid: Valid, backfill: Boolean) {
-                handle(valid)
-            }
-        }
-    }
-}
-
-class Command(private val invoke: String, private val helpString: String, private val handler: CommandHandler)
-    : CommandHandler by handler {
-    constructor(invoke: String, helpString: String, handle: (Valid) -> Unit) :
-        this(invoke, helpString, CommandHandler.fromHandle(handle))
-
+class Command(private val invoke: String, private val helpString: String, val handle: (Valid) -> Unit) {
     fun matches(message: Valid): Boolean {
         return message.contents.startsWith(invoke)
     }
@@ -27,3 +12,5 @@ class Command(private val invoke: String, private val helpString: String, privat
         return "$invoke -> $helpString"
     }
 }
+
+class PassiveCommand(val handle: (Passive) -> Unit)

--- a/src/main/kotlin/coffeebot/commands/Commands.kt
+++ b/src/main/kotlin/coffeebot/commands/Commands.kt
@@ -2,7 +2,23 @@ package coffeebot.commands
 
 import coffeebot.message.Valid
 
-class Command(private val invoke: String, private val helpString: String, val handle: (Valid) -> Unit) {
+interface CommandHandler {
+    fun handle(valid: Valid, backfill: Boolean)
+
+    companion object {
+        fun fromHandle(handle: (Valid) -> Unit) = object : CommandHandler {
+            override fun handle(valid: Valid, backfill: Boolean) {
+                handle(valid)
+            }
+        }
+    }
+}
+
+class Command(private val invoke: String, private val helpString: String, private val handler: CommandHandler)
+    : CommandHandler by handler {
+    constructor(invoke: String, helpString: String, handle: (Valid) -> Unit) :
+        this(invoke, helpString, CommandHandler.fromHandle(handle))
+
     fun matches(message: Valid): Boolean {
         return message.contents.startsWith(invoke)
     }

--- a/src/main/kotlin/coffeebot/commands/Dispatcher.kt
+++ b/src/main/kotlin/coffeebot/commands/Dispatcher.kt
@@ -50,17 +50,17 @@ class Dispatcher(private val db: Database?) {
 
     private fun loadDb() {
         db?.loadMessagesFromDb()?.forEach {
-            dispatch(it)
+            dispatch(it, backfill = true)
         }
     }
 
-    private fun dispatch(message: Valid) {
+    private fun dispatch(message: Valid, backfill: Boolean = false) {
         for (command in registered) {
             if (command.matches(message)) {
-                command.handle(message)
+                command.handle(message, backfill)
                 return
             }
         }
-        invalid.handle(message)
+        invalid.handle(message, backfill)
     }
 }

--- a/src/main/kotlin/coffeebot/commands/Dispatcher.kt
+++ b/src/main/kotlin/coffeebot/commands/Dispatcher.kt
@@ -28,6 +28,7 @@ class Dispatcher(private val db: Database?) {
                 .register(lisp)
                 .register(source)
                 .register(help)
+                .register(miltonIndex)
         this.loadDb()
     }
 

--- a/src/main/kotlin/coffeebot/commands/Milton.kt
+++ b/src/main/kotlin/coffeebot/commands/Milton.kt
@@ -1,0 +1,51 @@
+package coffeebot.commands
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.features.HttpTimeout
+import io.ktor.client.features.json.GsonSerializer
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import java.lang.IllegalStateException
+import java.net.MalformedURLException
+import java.net.URL
+
+class MiltonClient {
+    private val httpClient = HttpClient(OkHttp) {
+        install(JsonFeature) {
+            serializer = GsonSerializer()
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 45_000
+            socketTimeoutMillis = 45_000
+        }
+    }
+    private val miltonHost = "https://milton.terbium.io"
+
+    fun index(url: URL): Boolean {
+        val result = runBlocking(Dispatchers.IO) {
+            httpClient.post<HttpResponse>("$miltonHost/save?url=${url}")
+        }
+        return result.status == HttpStatusCode.OK
+    }
+}
+
+private val miltonClient = MiltonClient()
+private val indexRegex = "!index (.*)".toRegex()
+
+val miltonIndex = Command("!index", "Index an article to https://milton.terbium.io/") { valid ->
+    val match = indexRegex.matchEntire(valid.contents.trim())
+            ?: throw IllegalStateException("clearly this should never happen")
+    val urlValue = match.groups[1]!!.value
+    val url = try {
+        URL(urlValue)
+    } catch (e: MalformedURLException) {
+        valid.reply("invalid URL: $urlValue")
+        return@Command
+    }
+    miltonClient.index(url)
+}

--- a/src/main/kotlin/coffeebot/database/Database.kt
+++ b/src/main/kotlin/coffeebot/database/Database.kt
@@ -1,6 +1,7 @@
 package coffeebot.database
 
 import coffeebot.message.NullHandle
+import coffeebot.message.RepliableMessageHandle
 import coffeebot.message.User
 import coffeebot.message.Valid
 import java.io.File
@@ -20,7 +21,7 @@ class Database(fileName: String) {
             db.forEachLine { line ->
                 val user = line.substringBefore(',')
                 val content = line.substringAfter(',')
-                val msg = Valid(User(user), content, NullHandle)
+                val msg = Valid(User(user), content, RepliableMessageHandle(NullHandle))
                 messages.add(msg)
             }
         } else {

--- a/src/main/kotlin/coffeebot/message/Handle.kt
+++ b/src/main/kotlin/coffeebot/message/Handle.kt
@@ -1,23 +1,36 @@
 package coffeebot.message
 
+import discord4j.core.`object`.reaction.ReactionEmoji
 import discord4j.core.event.domain.message.MessageCreateEvent
 
 interface Handle {
     fun sendMessage(message: String)
+
+    fun react(emoji: String)
 }
 
 object NullHandle: Handle {
     override fun sendMessage(message: String) {}
+
+    override fun react(emoji: String) {}
 }
 
-object StdoutHandler: Handle {
+class StdoutHandler(private val baseMessage: String): Handle {
     override fun sendMessage(message: String) {
         println("BetBot: $message")
+    }
+
+    override fun react(emoji: String) {
+        println("Reacted $emoji to '$baseMessage'")
     }
 }
 
 class DiscordHandle(private val event: MessageCreateEvent): Handle {
     override fun sendMessage(message: String) {
         event.sendMessage(message)
+    }
+
+    override fun react(emoji: String) {
+        event.message.addReaction(ReactionEmoji.unicode(emoji))
     }
 }

--- a/src/main/kotlin/coffeebot/message/Message.kt
+++ b/src/main/kotlin/coffeebot/message/Message.kt
@@ -1,23 +1,36 @@
 package coffeebot.message
 
 fun loadMessage(user: User?, contents: String?, handle: Handle): Message {
-        return if (contents == null || user == null) {
-            Invalid
-        } else if (!contents.startsWith('!') || "CoffeeBot" == user.name) {
-            Ignored
-        } else {
-            Valid(user, contents, handle)
-        }
+    return if (contents == null || user == null) {
+        Invalid
+    } else if (!contents.startsWith('!') || "CoffeeBot" == user.name) {
+        Passive(user, contents, RepliableMessageHandle(handle))
+    } else {
+        Valid(user, contents, RepliableMessageHandle(handle))
+    }
+}
+
+interface RepliableMessage {
+    fun reply(message: String)
+    fun react(emoji: String)
+}
+
+class RepliableMessageHandle(private val handle: Handle) : RepliableMessage {
+    override fun reply(message: String) {
+        handle.sendMessage(message)
+    }
+
+    override fun react(emoji: String) {
+        handle.react(emoji)
+    }
 }
 
 sealed class Message
 
-data class Valid(val user: User, val contents: String, private val handle: Handle): Message() {
-    fun reply(message: String) {
-        handle.sendMessage(message)
-    }
-}
+data class Valid(val user: User, val contents: String, private val handle: RepliableMessage): Message(),
+        RepliableMessage by handle
 
-object Ignored: Message()
+data class Passive(val user: User, val contents: String, private val handle: RepliableMessage): Message(),
+        RepliableMessage by handle
 
 object Invalid: Message()

--- a/src/main/kotlin/coffeebot/processor/Offline.kt
+++ b/src/main/kotlin/coffeebot/processor/Offline.kt
@@ -25,10 +25,10 @@ class Offline: MessageProcessor {
                     user = match.groupValues.component2()
                     println("Switching to user $user")
                 } else if (line.startsWith("(")) {
-                    dispatcher.process(loadMessage(User(user), "!cl $line", StdoutHandler))
+                    dispatcher.process(loadMessage(User(user), "!cl $line", StdoutHandler(line)))
                 }
                 else {
-                    dispatcher.process(loadMessage(User(user), line, StdoutHandler))
+                    dispatcher.process(loadMessage(User(user), line, StdoutHandler(line)))
                 }
             } catch (e: Exception) {
                 println("You caused an error: ${e.message}")


### PR DESCRIPTION
This makes Coffebot check every message it sees for links and send said links to Milton.

I've had to turn the `Ignored` message type into a `Passive` type, and add a new type of handler for these messages. Currently, passive handlers won't look at `Valid` messages. This is fine for Milton, but I don't know if it's what we want in general.

Another possibly problematic point is that Milton requests can take a while, between cold-start times, page conversion, and sending the page chunks to the search engine, so maybe we want to revisit sequential processing in the future. I don't think this is a serious concern in the near term.