### PR TITLE
Add coffee payments tracker

### DIFF
--- a/src/main/kotlin/coffeebot/commands/CoffeeWager.kt
+++ b/src/main/kotlin/coffeebot/commands/CoffeeWager.kt
@@ -200,8 +200,11 @@ val totals = Command("!totals", "Show coffee debt totals") { message ->
                 } else {
                     Triple(CoffeeWager.person2, CoffeeWager.person1, CoffeeWager.coffees2)
                 }
+        // Make sure fromTo is in lexicographic order so that bets a -> b and b -> a can be summed
+        // together.
+        // Also, the non-null coercion is fine because all Completed wagers have non-null person1 and
+        // person2 entries.
         val (fromTo, inverter) = orderNames(wager[loserCol]!!, wager[winnerCol]!!)
-        // this is fine because all Completed wagers have non-null person1 and person2 entries.
         val current = totals.getOrDefault(fromTo, 0)
         totals[fromTo] = current + wager[coffeesCol] * inverter
     }

--- a/src/main/kotlin/coffeebot/commands/Dispatcher.kt
+++ b/src/main/kotlin/coffeebot/commands/Dispatcher.kt
@@ -32,7 +32,9 @@ class Dispatcher(private val log: Log?, miltonSecret: String?) {
                 .register(adjudicate)
                 .register(list)
                 .register(lisp)
+                .register(payOff)
                 .register(source)
+                .register(totals)
                 .register(help)
         this.loadFromLog()
     }
@@ -58,10 +60,10 @@ class Dispatcher(private val log: Log?, miltonSecret: String?) {
     private fun loadFromLog() {
         log?.loadMessagesFromLog()?.forEach {
             if (it.contents.startsWith("!cl")) {
-                println("Applying lisp: $it")
+                println("[Lisp] Applying lisp: $it")
                 dispatch(it)
             } else {
-                println("Ignoring message: $it")
+                println("[Lisp] Ignoring message: $it")
             }
         }
     }

--- a/src/main/kotlin/coffeebot/commands/Dispatcher.kt
+++ b/src/main/kotlin/coffeebot/commands/Dispatcher.kt
@@ -32,7 +32,7 @@ class Dispatcher(private val log: Log?, miltonSecret: String?) {
                 .register(adjudicate)
                 .register(list)
                 .register(lisp)
-                .register(payOff)
+                .register(pay)
                 .register(source)
                 .register(totals)
                 .register(help)

--- a/src/main/kotlin/coffeebot/database/Tables.kt
+++ b/src/main/kotlin/coffeebot/database/Tables.kt
@@ -4,25 +4,40 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.sql.Connection
+
+val NAME_LENGTH = 50
 
 enum class WagerState {
     Proposed,
     Accepted,
     Canceled,
     Completed,
-    PaidOff,
 }
 
 object CoffeeWager: IntIdTable() {
-    val person1 = varchar("person1", 50)
-    val person2 = varchar("person2", 50).nullable()
+    val person1 = varchar("person1", NAME_LENGTH)
+    val person2 = varchar("person2", NAME_LENGTH).nullable()
     val coffees1 = integer("coffees1")
     val coffees2 = integer("coffees2")
     val terms = varchar("terms", 500)
     val state = enumeration("state", WagerState::class)
-    val winner = varchar("winner", 50).nullable()
+    val winner = varchar("winner", NAME_LENGTH).nullable()
+}
+
+/**
+ * Represents an aggregate payment in coffees between two people.
+ *
+ * Invariant: `from` < `to` in lexicographic order
+ */
+object CoffeePayment: Table() {
+    val from = varchar("erson1", NAME_LENGTH)
+    val to = varchar("person1", NAME_LENGTH)
+    val amount = integer("amount")
+
+    override val primaryKey = PrimaryKey(from, to)
 }
 
 fun connect(filename: String) {
@@ -36,5 +51,6 @@ fun connect(filename: String) {
 fun createTables() {
     transaction {
         SchemaUtils.create(CoffeeWager)
+        SchemaUtils.create(CoffeePayment)
     }
 }

--- a/src/main/kotlin/coffeebot/database/Tables.kt
+++ b/src/main/kotlin/coffeebot/database/Tables.kt
@@ -12,6 +12,7 @@ enum class WagerState {
     Accepted,
     Canceled,
     Completed,
+    PaidOff,
 }
 
 object CoffeeWager: IntIdTable() {

--- a/src/main/kotlin/coffeebot/database/Tables.kt
+++ b/src/main/kotlin/coffeebot/database/Tables.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.sql.Connection
 
-val NAME_LENGTH = 50
+private const val NAME_LENGTH = 50
 
 enum class WagerState {
     Proposed,
@@ -33,9 +33,9 @@ object CoffeeWager: IntIdTable() {
  * Invariant: `from` < `to` in lexicographic order
  */
 object CoffeePayment: Table() {
-    val from = varchar("erson1", NAME_LENGTH)
-    val to = varchar("person1", NAME_LENGTH)
-    val amount = integer("amount")
+    val from = varchar("from", NAME_LENGTH)
+    val to = varchar("to", NAME_LENGTH)
+    val coffees = integer("coffees")
 
     override val primaryKey = PrimaryKey(from, to)
 }

--- a/src/main/kotlin/coffeebot/database/WagerDao.kt
+++ b/src/main/kotlin/coffeebot/database/WagerDao.kt
@@ -111,6 +111,24 @@ fun adjudicateWager(id: Int, whoWon: String): Result {
 }
 
 /**
+ * Mark a wager as having been paid off.
+ * @param id: Id of wager to make as paid off
+ * @return: Whether or not the wager was successfully marked as paid off
+ */
+fun payOffWager(id: Int): Result {
+    return transaction {
+        val modified = CoffeeWager.update({ CoffeeWager.id eq id }) {
+            it[state] = WagerState.PaidOff
+        }
+        return@transaction if (modified == 1) {
+            Result.Success
+        } else {
+            Result.Failure
+        }
+    }
+}
+
+/**
  * Get a Wager by id.
  */
 fun getId(id: Int): ResultRow? {
@@ -137,9 +155,14 @@ fun getActiveWagers(): List<ResultRow> = getRowsInState(WagerState.Accepted)
 fun getCanceledWagers(): List<ResultRow> = getRowsInState(WagerState.Canceled)
 
 /**
- * Get completed wagers, sorted by id.
+ * Get completed wagers that haven't been paid off, sorted by id.
  */
 fun getCompletedWagers(): List<ResultRow> = getRowsInState(WagerState.Completed)
+
+/**
+ * Get paid off wagers, sorted by id.
+ */
+fun getPaidOffWagers(): List<ResultRow> = getRowsInState(WagerState.PaidOff)
 
 private fun getRowsInState(state: WagerState): List<ResultRow> {
     return transaction {

--- a/src/test/kotlin/database/WagerDaoTest.kt
+++ b/src/test/kotlin/database/WagerDaoTest.kt
@@ -1,0 +1,76 @@
+package database
+
+import coffeebot.commands.pay
+import coffeebot.database.*
+import org.junit.Test
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+class WagerDaoTest {
+    private val testDb = "coffeebot-test.db"
+    private val defaultTerms = "That I the coffee-counting system definitely doesn't work"
+
+    private val caboose = "caboose"
+    private val ishansAnnoyingUsername = "iiiiiiiiiiiiiiiiiiiivash"
+    private val jason = "jason"
+    private val zale = "zale"
+
+    @BeforeTest
+    fun before() {
+        File(testDb).delete()
+        connect(testDb)
+        createTables()
+    }
+
+    @AfterTest
+    fun after() {
+        File(testDb).delete()
+    }
+
+    @Test
+    fun testBalanceWagersOnly() {
+        var id = proposeWager(zale, 3, 5, defaultTerms)
+        acceptWager(caboose, id)
+        adjudicateWager(id, zale)
+
+        id = proposeWager(caboose, 1, 4, "yeah IDK something I would win")
+        acceptWager(zale, id)
+        adjudicateWager(id, caboose)
+
+        id = proposeWager(ishansAnnoyingUsername, 2, 1, "bernie wins the primary")
+        acceptWager(jason, id)
+        adjudicateWager(id, jason)
+
+        val payments = getBalancePayments().map { it.toPositive() }.toSet()
+        assertEquals(
+                // zale has won 5 coffees, and caboose has won 4, so the settlement payment is caboose -> zale 1
+                setOf(PositivePayment(caboose, zale, 1), PositivePayment(ishansAnnoyingUsername, jason, 2)),
+                payments
+        )
+    }
+
+    @Test
+    fun testBalancePaymentsOnly() {
+        addPayment(Payment.payment(jason, ishansAnnoyingUsername, 2))
+        addPayment(Payment.payment(jason, ishansAnnoyingUsername, 1))
+        addPayment(Payment.payment(ishansAnnoyingUsername, jason, -1))
+        addPayment(Payment.payment(ishansAnnoyingUsername, caboose, 1))
+        val payments = getBalancePayments().map { it.toPositive() }.toSet()
+        assertEquals(
+                setOf(PositivePayment(ishansAnnoyingUsername, jason, 4), PositivePayment(caboose, ishansAnnoyingUsername, 1)),
+                payments
+        )
+    }
+
+    @Test
+    fun testBalanceAggregate() {
+        val id = proposeWager(zale, 3, 5, defaultTerms)
+        acceptWager(caboose, id)
+        adjudicateWager(id, zale)
+
+        addPayment(Payment.payment(caboose, zale, 2))
+        assertEquals(listOf(PositivePayment(caboose, zale, 3)), getBalancePayments().map { it.toPositive() })
+    }
+}


### PR DESCRIPTION
This adds a new table to track payments (really payment balances) in coffees between people, and a new command to declare a payment.

With this plus the list of adjudicated wagers, we can compute total balances of coffees between each pair of people.